### PR TITLE
A fix for run_tests.sh failing if Selenium is absent.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -161,8 +161,16 @@ function wait_for_selenium {
 function run_tests {
   if [ $selenium -eq 0 ]; then
     echo "Starting Selenium server..."
-    ${django_wrapper} horizon/bin/seleniumrc > .selenium_log &
-    wait_for_selenium
+    
+    if [ -f horizon/bin/seleniumrc ]; then
+        echo "Selenium Installed"
+        ${django_wrapper} horizon/bin/seleniumrc > .selenium_log &
+        wait_for_selenium
+      else
+        echo "Selenium Not Installed"
+        selenium=1
+    fi
+    
   fi
 
   echo "Running Horizon application tests"


### PR DESCRIPTION
In the event Selenium isn't present, the script currently fails, see:
https://bugs.launchpad.net/horizon/+bug/887885
this fix checks for the presence of the Selenium, then if the server
isn't available fails through and runs run dashboard/manage.py test
rather than dashboard/manage.py test --with-selenium
--with-cherrypyliveserver ensuring the user can still start the
development environment.
