### PR TITLE
Adjust for changes in novaclient 

### DIFF
--- a/horizon/horizon/api/nova.py
+++ b/horizon/horizon/api/nova.py
@@ -139,7 +139,7 @@ def novaclient(request):
     LOG.debug('novaclient connection created using token "%s" and url "%s"' %
               (request.user.token, url_for(request, 'compute')))
     c = nova_client.Client(username=request.user.username,
-                      api_key=request.user.token,
+                      password=request.user.token,
                       project_id=request.user.tenant_id,
                       auth_url=url_for(request, 'compute'))
     c.client.auth_token = request.user.token


### PR DESCRIPTION
novaclient has deprecated api_key, switching to password
   https://github.com/openstack/python-novaclient/commit/1f4971a1360b27ce25d05a1d6d518ca53856a649)
