### PR TITLE
add patch (bug898510)

### DIFF
--- a/horizon/horizon/context_processors.py
+++ b/horizon/horizon/context_processors.py
@@ -63,6 +63,8 @@ def horizon(request):
             context['authorized_tenants'] = tenants
         except Exception, e:
             if hasattr(request.user, 'message_set'):
+                if not hasattr(e, 'message'):
+                    e.message = str(e)
                 messages.error(request, _("Unable to retrieve tenant list: %s")
                                % e.message)
             else:

--- a/horizon/horizon/dashboards/nova/images_and_snapshots/images/views.py
+++ b/horizon/horizon/dashboards/nova/images_and_snapshots/images/views.py
@@ -115,6 +115,8 @@ def launch(request, image_id):
     try:
         quotas.ram = int(quotas.ram)
     except Exception, e:
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request,
                 _('Error parsing quota  for %(image)s: %(msg)s') %
                 {"image": image_id, "msg": e.message})

--- a/horizon/horizon/dashboards/nova/instances_and_volumes/instances/views.py
+++ b/horizon/horizon/dashboards/nova/instances_and_volumes/instances/views.py
@@ -54,6 +54,8 @@ def index(request):
         instances = api.server_list(request)
     except Exception as e:
         LOG.exception(_('Exception in instance index'))
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get instance list: %s')
                        % e.message)
 
@@ -69,6 +71,8 @@ def index(request):
         messages.error(request, _('Unauthorized.'))
     except Exception, e:
         LOG.exception('Exception while fetching flavor info')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get flavor info: %s') % e.message)
 
     # We don't have any way of showing errors for these, so don't bother

--- a/horizon/horizon/dashboards/nova/networks/forms.py
+++ b/horizon/horizon/dashboards/nova/networks/forms.py
@@ -42,6 +42,8 @@ class CreateNetwork(forms.SelfHandlingForm):
             send_data = {'network': {'name': '%s' % network_name}}
             api.quantum_create_network(request, send_data)
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                            _('Unable to create network %(network)s: %(msg)s') %
                            {"network": network_name, "msg": e.message})
@@ -61,6 +63,8 @@ class DeleteNetwork(forms.SelfHandlingForm):
             LOG.info('Deleting network %s ' % data['network'])
             api.quantum_delete_network(request, data['network'])
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                     _('Unable to delete network %(network)s: %(msg)s') %
                     {"network": data['network'], "msg": e.message})
@@ -83,6 +87,8 @@ class RenameNetwork(forms.SelfHandlingForm):
             send_data = {'network': {'name': '%s' % data['new_name']}}
             api.quantum_update_network(request, data['network'], send_data)
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                     _('Unable to rename network %(network)s: %(msg)s') %
                     {"network": data['network'], "msg": e.message})
@@ -106,6 +112,8 @@ class CreatePort(forms.SelfHandlingForm):
             for i in range(0, data['ports_num']):
                 api.quantum_create_port(request, data['network'])
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                 _('Unable to create ports on network %(network)s: %(msg)s') %
                 {"network": data['network'], "msg": e.message})
@@ -128,6 +136,8 @@ class DeletePort(forms.SelfHandlingForm):
                      (data['port'], data['network']))
             api.quantum_delete_port(request, data['network'], data['port'])
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                            _('Unable to delete port %(port)s: %(msg)s') %
                            {"port": data['port'], "msg": e.message})
@@ -166,6 +176,8 @@ class AttachPort(forms.SelfHandlingForm):
             api.quantum_attach_port(request,
                                         data['network'], data['port'], body)
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                 _('Unable to attach port %(port)s to VIF %(vif)s: %(msg)s') %
                 {"port": data['port'],
@@ -188,6 +200,8 @@ class DetachPort(forms.SelfHandlingForm):
             LOG.info('Detaching port %s' % data['port'])
             api.quantum_detach_port(request, data['network'], data['port'])
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                 _('Unable to detach port %(port)s: %(message)s') %
                 {"port": data['port'], "message": e.message})
@@ -210,6 +224,8 @@ class TogglePort(forms.SelfHandlingForm):
             api.quantum_set_port_state(request,
                                        data['network'], data['port'], body)
         except Exception, e:
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                 _('Unable to set port state to %(state)s: %(message)s') %
                 {"state": data['state'], "message": e.message})

--- a/horizon/horizon/dashboards/nova/networks/views.py
+++ b/horizon/horizon/dashboards/nova/networks/views.py
@@ -64,6 +64,8 @@ def index(request):
 
     except Exception, e:
         LOG.exception("Unable to get network list.")
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request,
                        _('Unable to get network list: %s') % e.message)
 
@@ -101,6 +103,8 @@ def detail(request, network_id):
         network['ports'] = _get_port_states(request, network_id)
     except Exception, e:
         LOG.exception("Unable to get network details.")
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request,
                        _('Unable to get network details: %s') % e.message)
         return shortcuts.redirect("horizon:nova:networks:index")

--- a/horizon/horizon/dashboards/syspanel/flavors/views.py
+++ b/horizon/horizon/dashboards/syspanel/flavors/views.py
@@ -53,6 +53,8 @@ def index(request):
         messages.error(request, _('Unauthorized.'))
     except Exception, e:
         LOG.exception('Exception while fetching usage info')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get flavor list: %s') % e.message)
 
     flavors.sort(key=lambda x: x.id, reverse=True)

--- a/horizon/horizon/dashboards/syspanel/instances/views.py
+++ b/horizon/horizon/dashboards/syspanel/instances/views.py
@@ -263,6 +263,8 @@ def index(request):
         instances = api.admin_server_list(request)
     except Exception as e:
         LOG.exception('Unspecified error in instance index')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request,
                        _('Unable to get instance list: %s') % e.message)
 
@@ -289,6 +291,8 @@ def refresh(request):
     try:
         instances = api.admin_server_list(request)
     except Exception as e:
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request,
                        _('Unable to get instance list: %s') % e.message)
 

--- a/horizon/horizon/dashboards/syspanel/quotas/views.py
+++ b/horizon/horizon/dashboards/syspanel/quotas/views.py
@@ -39,6 +39,8 @@ def index(request):
     except Exception, e:
         quotas = None
         LOG.exception('Exception while getting quota info')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get quota info: %s') % e.message)
 
     return shortcuts.render(request,

--- a/horizon/horizon/dashboards/syspanel/tenants/forms.py
+++ b/horizon/horizon/dashboards/syspanel/tenants/forms.py
@@ -180,6 +180,8 @@ class DeleteTenant(forms.SelfHandlingForm):
                                      % {"tenant": tenant_id})
         except Exception, e:
             LOG.exception("Error deleting tenant")
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                            _("Error deleting tenant: %s") % e.message)
         return shortcuts.redirect(request.build_absolute_uri())

--- a/horizon/horizon/dashboards/syspanel/tenants/views.py
+++ b/horizon/horizon/dashboards/syspanel/tenants/views.py
@@ -51,6 +51,8 @@ def index(request):
         messages.error(request, _('Unable to get tenant info: %s') % e.message)
     except Exception, e:
         LOG.exception('Exception while getting tenant list')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get tenant info: %s') % e.message)
 
     tenants.sort(key=lambda x: x.id, reverse=True)

--- a/horizon/horizon/dashboards/syspanel/users/forms.py
+++ b/horizon/horizon/dashboards/syspanel/users/forms.py
@@ -75,6 +75,8 @@ class UserForm(BaseUserForm):
             except Exception, e:
                 LOG.exception('Exception while assigning \
                                role to new user: %s' % new_user.id)
+                if not hasattr(e, 'message'):
+                    e.message = str(e)
                 messages.error(request,
                                _('Error assigning role to user: %s')
                                % e.message)
@@ -85,6 +87,8 @@ class UserForm(BaseUserForm):
             LOG.exception('Exception while creating user\n'
                       'name: "%s", email: "%s", tenant_id: "%s"' %
                       (data['name'], data['email'], data['tenant_id']))
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request,
                             _('Error creating user: %s')
                              % e.message)

--- a/horizon/horizon/dashboards/syspanel/users/views.py
+++ b/horizon/horizon/dashboards/syspanel/users/views.py
@@ -50,6 +50,8 @@ def index(request):
         messages.error(request, _('Unable to get user info: %s') % e.message)
     except Exception, e:
         LOG.exception('Exception while getting user list')
+        if not hasattr(e, 'message'):
+            e.message = str(e)
         messages.error(request, _('Unable to get user info: %s') % e.message)
 
     user_delete_form = UserDeleteForm()

--- a/horizon/horizon/forms.py
+++ b/horizon/horizon/forms.py
@@ -212,6 +212,8 @@ class SelfHandlingForm(Form):
             if issubclass(e.__class__, exceptions.NotAuthorized):
                 # Let the middleware handle it as intended.
                 raise
+            if not hasattr(e, 'message'):
+                e.message = str(e)
             messages.error(request, _('%s') % e.message)
             return form, None
 


### PR DESCRIPTION
https://bugs.launchpad.net/horizon/+bug/898510

files affected:
https://gist.github.com/1470104

detailed info:
https://gist.github.com/1470094

I did a hasattr check whenever the code tries to access the message attribute of a BaseException.

Since openstackx, glance, and quantum implements their exceptions with a message attribute, I thought keeping the message attribute access was logical.

I couldn't write the test code since evoking an exception on views and forms was impossible.

I could've made a duplicate module and import a fake api and raise the exception but that seemed too messy.

If you need unittests I'll have to look more into it.
