### PR TITLE
Integrate horizon volume part with ceph radosgw

### DIFF
--- a/horizon/exceptions.py
+++ b/horizon/exceptions.py
@@ -109,6 +109,15 @@ class AlreadyExists(HorizonException):
     def __unicode__(self):
         return _(self.msg) % self.attrs
 
+class RadosgwExceptions(HorizonException):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+    def __unicode__(self):
+        return _(self.msg)
 
 class HandledException(HorizonException):
     """
@@ -148,7 +157,8 @@ RECOVERABLE = (keystoneclient.ClientException,
                novaclient.ClientException,
                glanceclient.GlanceException,
                swiftclient.Error,
-               AlreadyExists)
+               AlreadyExists,
+               RadosgwExceptions)
 RECOVERABLE += tuple(EXCEPTION_CONFIG.get('recoverable', []))
 
 


### PR DESCRIPTION
Ceph rados gateway has supported swift api, but has not supported to integrate with keystone identity.
However, Horizon supply a view to manipulate object to backend swift component
, only using keystone identity.

So, I just add 2 more options in local_settings.py :

SWIFT_USE_RADOSGW_AUTH : bool 
SYNC_KEYSTONE_RADOSGW_AUTH : bool

in order to specify whether use the authentication of radosgw, 
and whether sync authentication between keystone and radosgw automatically.
