### PR TITLE
Invalid Content-Length creating a folder in reversed proxy environment

### DIFF
--- a/openstack_dashboard/api/swift.py
+++ b/openstack_dashboard/api/swift.py
@@ -229,8 +229,8 @@ def swift_copy_object(request, orig_container_name, orig_object_name,
 
 
 def swift_create_subfolder(request, container_name, folder_name):
-    headers = {'content-type': 'application/directory',
-               'content-length': 0}
+    headers = {'Content-Type': 'application/directory',
+               'Content-Length': 0}
     etag = swift_api(request).put_object(container_name,
                                          folder_name,
                                          None,


### PR DESCRIPTION
Using apache as a reverse proxy for API access and SSL offloading I'm getting the following errortrying to create a folder on swift.

```
==> /var/log/apache2/os_ssl_error.log <==
[Thu Dec 20 15:26:46 2012] [error] [client xx.xx.xx.xx] Invalid Content-Length
[Thu Dec 20 15:26:46 2012] [error] (-3)Unknown error -3: proxy: prefetch request body failed to xx.xx.xx.xx:8888 (os-controller-int-02.xx.xx) from xx.xx.xx.xx ()
```

This error raises since apache seems to erroneously expect a capitalized Content-Length header. 
