### PR TITLE
Addes Content-Length header for swift_upload_object.

### DIFF
--- a/openstack_dashboard/api/swift.py
+++ b/openstack_dashboard/api/swift.py
@@ -208,6 +208,7 @@ def swift_copy_object(request, orig_container_name, orig_object_name,
 def swift_upload_object(request, container_name, object_name, object_file):
     headers = {}
     headers['X-Object-Meta-Orig-Filename'] = object_file.name
+	headers['Content-Length'] = object_file.size
     etag = swift_api(request).put_object(container_name,
                                          object_name,
                                          object_file,


### PR DESCRIPTION
We use radosgw for our object-store. I added Content-Length Header which is mandatory for Radosgw/Apache when uploading via Horizon.

This may break legacy swift access and needs testing.

Kind Regards
Oliver
