### PR TITLE
Fix typo in horizon.tabs.js, evt != event

### DIFF
--- a/horizon/static/horizon/js/horizon.tabs.js
+++ b/horizon/static/horizon/js/horizon.tabs.js
@@ -72,7 +72,7 @@ horizon.addInitFunction(function () {
     var $this = $(this),
       next_pane = $this.closest(".tab-pane").next(".tab-pane");
     // Capture the forward-tab keypress if we have a next tab to go to.
-    if (evt.which === 9 && !event.shiftKey && next_pane.length) {
+    if (evt.which === 9 && !evt.shiftKey && next_pane.length) {
       evt.preventDefault();
       $(".nav-tabs a[data-target='#" + next_pane.attr("id") + "']").tab('show');
     }
@@ -81,7 +81,7 @@ horizon.addInitFunction(function () {
     var $this = $(this),
       prev_pane = $this.closest(".tab-pane").prev(".tab-pane");
     // Capture the forward-tab keypress if we have a next tab to go to.
-    if (event.shiftKey && evt.which === 9 && prev_pane.length) {
+    if (evt.shiftKey && evt.which === 9 && prev_pane.length) {
       evt.preventDefault();
       $(".nav-tabs a[data-target='#" + prev_pane.attr("id") + "']").tab('show');
       prev_pane.find(":input:last").focus();


### PR DESCRIPTION
breaks keyboard navigation between tabs /w: "event is not defined"
