### PR TITLE
Use floats instead of integer in memory calculation of admin dashboard

### DIFF
--- a/openstack_dashboard/dashboards/admin/hypervisors/templates/hypervisors/index.html
+++ b/openstack_dashboard/dashboards/admin/hypervisors/templates/hypervisors/index.html
@@ -20,7 +20,7 @@
     <div class="d3_quota_bar">
     <div class="d3_pie_chart_usage" data-used="{% widthratio stats.memory_mb_used stats.memory_mb 100 %}"></div>
      <strong>{% trans "Memory Usage" %} <br />
-         {% blocktrans with used=stats.memory_mb_used|mbformat available=stats.memory_mb|mbformat %}Used <span> {{ used }} </span> of <span> {{ available }} </span>{% endblocktrans %}
+         {% blocktrans with used=stats.memory_mb_used|mb_float_format available=stats.memory_mb|mb_float_format %}Used <span> {{ used }} </span> of <span> {{ available }} </span>{% endblocktrans %}
      </strong>
     </div>
 


### PR DESCRIPTION
In the case that hypervisors have large amounts of memory, you'll find that the dashboard reports improper memory usage when in the TB and PB range. For example, 1.95 TB as an integer equals 1...
