### PR TITLE
make horizon and scss work under linux and window OS

### DIFF
--- a/scss-window.md
+++ b/scss-window.md
@@ -1,0 +1,1 @@
+To make horizon work on both of Linux and Window OS. The "/" code should be replaced by path separator which depends on the OS


### PR DESCRIPTION
use os.path.directory_separator to replace "/"