### PR TITLE
Make horizon always pass None as a device path/id.

### DIFF
--- a/openstack_dashboard/api/nova.py
+++ b/openstack_dashboard/api/nova.py
@@ -751,7 +751,7 @@ def get_password(request, instance_id, private_key=None):
 def instance_volume_attach(request, volume_id, instance_id, device):
     return novaclient(request).volumes.create_server_volume(instance_id,
                                                             volume_id,
-                                                            device)
+                                                            None)
 
 
 def instance_volume_detach(request, instance_id, att_id):


### PR DESCRIPTION
A fix for the bug described here:
https://bugs.launchpad.net/horizon/+bug/1492450