### PR TITLE
Added a way to change instance's root password from the Dashboard

### DIFF
--- a/openstack_dashboard/api/nova.py
+++ b/openstack_dashboard/api/nova.py
@@ -848,6 +848,10 @@ def get_password(request, instance_id, private_key=None):
     return novaclient(request).servers.get_password(instance_id, private_key)
 
 
+def change_password(request, instance_id, password):
+    return novaclient(request).servers.change_password(instance_id, password)
+
+
 def instance_volume_attach(request, volume_id, instance_id, device):
     return novaclient(request).volumes.create_server_volume(instance_id,
                                                             volume_id,


### PR DESCRIPTION
This patch adds feature "nova root-password" into the dashboard.

Project -> Compute -> Instances -> Edit Instance -> Root Password

I know that you likely won't merge this but this's important for history of pull requests (even declined) — if somebody (like me) will need in this feature.

![screenshot from 2016-10-03 12 06 54](https://cloud.githubusercontent.com/assets/2349376/19032364/efd02be6-8961-11e6-91ce-1c172deb784a.png)