### PR TITLE
to fix network/subnet update issue

### DIFF
--- a/openstack_dashboard/dashboards/project/networks/subnets/views.py
+++ b/openstack_dashboard/dashboards/project/networks/subnets/views.py
@@ -90,9 +90,6 @@ class UpdateView(workflows.WorkflowView):
                 subnet['ipv6_ra_mode'], subnet['ipv6_address_mode'])
 
         initial['dns_nameservers'] = '\n'.join(subnet['dns_nameservers'])
-        pools = ['%s,%s' % (p['start'], p['end'])
-                 for p in subnet['allocation_pools']]
-        initial['allocation_pools'] = '\n'.join(pools)
         routes = ['%s,%s' % (r['destination'], r['nexthop'])
                   for r in subnet['host_routes']]
         initial['host_routes'] = '\n'.join(routes)

--- a/openstack_dashboard/dashboards/project/networks/subnets/workflows.py
+++ b/openstack_dashboard/dashboards/project/networks/subnets/workflows.py
@@ -125,6 +125,8 @@ class UpdateSubnetInfo(CreateSubnetInfo):
 
 
 class UpdateSubnetDetailAction(network_workflows.CreateSubnetDetailAction):
+    allocation_pools = forms.CharField(widget=forms.HiddenInput(),
+                                       required=False)
 
     def __init__(self, request, context, *args, **kwargs):
         super(UpdateSubnetDetailAction, self).__init__(request, context,


### PR DESCRIPTION
We have receiving issues while updating network/subnet. 
Error details : 
> Failed to update subnet "192.168.10.0/24": Bad subnet request: update of allocation_pools is not allowed
hence removed allocation pool details from view.py while from update subnet function and allocation pool option hidden in workflow.py to fix issue