### PR TITLE
fix bug : Lack of dependence python-memcached

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ oslo.utils>=3.33.0 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0
 pymongo!=3.1,>=3.0.2 # Apache-2.0
 pyScss!=1.3.5,>=1.3.4 # MIT License
+python-memcached>=1.11.0 # Apache-2.0
 python-cinderclient>=3.3.0 # Apache-2.0
 python-glanceclient>=2.8.0 # Apache-2.0
 python-keystoneclient>=3.15.0 # Apache-2.0


### PR DESCRIPTION
It will prompt “no module name memcached” when login in