### PR TITLE
Fixed wrong path in WSGI

### DIFF
--- a/openstack_dashboard/wsgi.py
+++ b/openstack_dashboard/wsgi.py
@@ -22,7 +22,7 @@ from django.core.wsgi import get_wsgi_application
 
 # Add this file path to sys.path in order to import settings
 sys.path.insert(0, os.path.normpath(os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), '../..')))
+    os.path.dirname(os.path.realpath(__file__)), '..')))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'openstack_dashboard.settings'
 sys.stdout = sys.stderr
 


### PR DESCRIPTION
When horizon/openstack_dashboard/wsgi/django.wsgi was moved to  horizon/openstack_dashboard/wsgi.py old path was left behind causing initialization error as it can not find openstack_dashboard.settings module. I've fixed it by removing one path level.
