### PR TITLE
replace policy check function getter

### DIFF
--- a/horizon/tables/base.py
+++ b/horizon/tables/base.py
@@ -44,7 +44,7 @@ from horizon import messages
 from horizon.tables.actions import BatchAction
 from horizon.tables.actions import FilterAction
 from horizon.tables.actions import LinkAction
-from horizon.utils import html
+from horizon.utils import html, settings as utils_settings
 
 
 LOG = logging.getLogger(__name__)
@@ -379,7 +379,7 @@ class Column(html.HTMLElement):
         if not self.policy_rules:
             return True
 
-        policy_check = getattr(settings, "POLICY_CHECK_FUNCTION", None)
+        policy_check = utils_settings.import_setting("POLICY_CHECK_FUNCTION")
 
         if policy_check:
             return policy_check(self.policy_rules, request)


### PR DESCRIPTION
previously, `policy_check` was a string instead of a real function, raising the `TypeError: 'str' object is not callable` error.
with `utils_settings.import_setting("POLICY_CHECK_FUNCTION")` the real function is fetched.