### PR TITLE
fix: set Django minimum version to 4.2.26 to address CVE-2025-64459 and CVE-2025-57833

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pbr>=5.5.0 # Apache-2.0
 
 # Horizon Core Requirements
 Babel>=2.6.0 # BSD
-Django>=4.2,<4.3 # BSD
+Django>=4.2.26,<4.3 # BSD
 django-compressor>=4.4 # MIT
 django-debreach>=1.4.2 # BSD License (2 clause)
 futurist>=1.2.0 # Apache-2.0


### PR DESCRIPTION
## What

Bumps the Django lower bound from `>=4.2` to `>=4.2.26` in `requirements.txt`.

## Why

The current constraint `Django>=4.2,<4.3` allows installing versions affected by two SQL injection CVEs.

**CVE-2025-64459 (CVSS 9.1)**

SQL injection via `Q()` and `QuerySet.filter()` keyword argument unpacking. If `_connector` or `_negated` are present as keys in user-controlled input passed to these methods, an attacker can manipulate the generated SQL `WHERE` clause. This enables authentication bypass and unauthorized data access.

Fixed in Django 4.2.26, 5.1.14, 5.2.8.

**CVE-2025-57833 (CVSS high)**

SQL injection via `FilteredRelation` alias injection through `QuerySet.annotate()` and `QuerySet.alias()`. Fixed in Django 4.2.24, 5.1.12, 5.2.6.

Setting `>=4.2.26` covers both CVEs for the 4.2.x branch.

## Change

```
- Django>=4.2,<4.3 # BSD
+ Django>=4.2.26,<4.3 # BSD
```

References:
- https://www.djangoproject.com/weblog/2025/nov/05/security-releases/
- https://nvd.nist.gov/vuln/detail/CVE-2025-64459